### PR TITLE
Resuelto: Acción delete funciona correctamente

### DIFF
--- a/application/core/modelo2.php
+++ b/application/core/modelo2.php
@@ -171,12 +171,14 @@ class Modelo{
 		$query->execute($array_parameters);
 	}
 
-	function delete ($table, $params = null, $entity = false){
-		if($params != null){
-			$sql = "DELETE FROM $table WHERE id = :".$params[0];
+	//eliminado parametro $entity de momento
+	function delete ($table, $song_id = 0){
+		if($song_id != 0){
+			$sql = "DELETE FROM $table WHERE id = ".$song_id;
+			//d($sql);
 			$query = $this->db->prepare($sql);
 			$clave = ":id";
-			$valor = $params[0];
+			$valor = $song_id;
 			//d($valor);
 			$parameters = array();
 			$parameters[$clave] = $valor;

--- a/application/modulos/songs/Csongs.php
+++ b/application/modulos/songs/Csongs.php
@@ -64,9 +64,9 @@ class Csongs extends Controlador {
       if (isset($song_id)) {
           // do deleteSong() in model/model.php
           $this->model->deleteSong("song",$song_id);
-      }
+        }
 
-      // where to go after song has been deleted
+      // redirect user to songs index page (as we don't have a song_id)
       header('location: ' . URL . 'songs/index');
     }
 

--- a/application/modulos/songs/Msongs.php
+++ b/application/modulos/songs/Msongs.php
@@ -39,9 +39,9 @@ class Msongs extends Modelo {
      * add/update/delete stuff!
      * @param int $song_id Id of song
      */
-    public function deleteSong($table, $song_id, $entity = null){
+    public function deleteSong($table, $song_id){
       echo "Hola desde deleteSong";
-      $this->delete($table, $song_id, $entity);
+      $this->delete($table, $song_id);
     }
 
     /**


### PR DESCRIPTION
El controlador Csong.php y el modelo específico Msong.php no funcionaban porque no coincidían el número de parámetros entre la llamada y la declaración del métodos deleteSong(). Había un parámetro llamado $entity que en principio no tiene utilidad, así que se ha eliminado.

El método Delete del CRUD del modelo principal no estaba bien, ha habido que corregir algunas líneas para que algunos índices y nombres de variables se ejecutasen correctamente, de tal forma que cuando se ejecuta el $query->execute(), el registro es eliminado de la tabla "song".

En estos momento, el método delete del módulo principal elimina un registro seleccionado reviamente por su identificador.
